### PR TITLE
Add `librosa` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # pinned dependencies to reproduce a working development environment
-hdmf==3.1.1
-pynwb==2.0.0
-librosa==0.9.2
+hdmf>=3.1.1
+pynwb>=2.0.0
+librosa>=0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # pinned dependencies to reproduce a working development environment
 hdmf==3.1.1
 pynwb==2.0.0
+librosa==0.9.2


### PR DESCRIPTION
Installing `librosa` is needed for using the widgets, but since it is not listed in the requirements, installing it from source would raise an error: `ModuleNotFoundError: No module named 'librosa'`